### PR TITLE
Checking for array key to prevent php warning

### DIFF
--- a/disable-updates.php
+++ b/disable-updates.php
@@ -299,7 +299,12 @@ class OS_Disable_WordPress_Updates {
 		$url_data = parse_url( $url );
 
 		/* block request */
-		if( false !== stripos( $host, 'api.wordpress.org' ) && (false !== stripos( $url_data['path'], 'update-check' ) || false !== stripos( $url_data['path'], 'version-check' ) || false !== stripos( $url_data['path'], 'browse-happy' ) || false !== stripos( $url_data['path'], 'serve-happy' )) ) {
+		if( false !== stripos( $host, 'api.wordpress.org' ) &&
+		    isset( $url_data['path'] ) &&
+		    (false !== stripos( $url_data['path'], 'update-check' ) ||
+		     false !== stripos( $url_data['path'], 'version-check' ) ||
+		     false !== stripos( $url_data['path'], 'browse-happy' ) ||
+		     false !== stripos( $url_data['path'], 'serve-happy' )) ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Expected Behavior
Expecting no warning 😄 

## Current Behavior
PHP message: PHP Warning:  Undefined array key "path" in /var/www/htdocs/web/wp-content/plugins/disable-wordpress-updates/disable-updates.php on line 302

occurs since get_test_dotorg_communication() calls wp_remote_get() on https://api.wordpress.org, therefor parse_url returns an array without the key 'path'

**Stacktrace:**
disable-updates.php:302, OS_Disable_WordPress_Updates->block_request()
class-wp-hook.php:308, WP_Hook->apply_filters()
plugin.php:205, apply_filters()
class-wp-http.php:258, WP_Http->request()
class-wp-http.php:633, WP_Http->get()
http.php:162, wp_remote_get()
class-wp-site-health.php:1429, WP_Site_Health->get_test_dotorg_communication()
class-wp-rest-site-health-controller.php:225, WP_REST_Site_Health_Controller->test_dotorg_communication()
class-wp-rest-server.php:1171, WP_REST_Server->respond_to_request()
class-wp-rest-server.php:1018, WP_REST_Server->dispatch()
class-wp-rest-server.php:442, WP_REST_Server->serve_request()
rest-api.php:410, rest_api_loaded()
class-wp-hook.php:308, WP_Hook->apply_filters()
class-wp-hook.php:332, WP_Hook->do_action()
plugin.php:565, do_action_ref_array()
class-wp.php:399, WP->parse_request()
class-wp.php:780, WP->main()
functions.php:1332, wp()
wp-blog-header.php:16, require_once()
index.php:19, {main}()

## Steps to Reproduce
1. Call site-health.php
2. Check the logs

## Context (Environment)
Using WP 6.1.1 & disable-wordpress-updates 1.7.0

## Possible solution
See below